### PR TITLE
infraspecific name bug

### DIFF
--- a/includes/TripalImporter/GermplasmAccessionImporter.inc
+++ b/includes/TripalImporter/GermplasmAccessionImporter.inc
@@ -347,7 +347,7 @@
         'genus' => $genus,
         'species' => $one_accession['germplasm_species']
       );
-      if ($one_accession['subtaxa']){
+      if (!empty($one_accession['subtaxa'])){
         $match['infraspecific_name'] = $one_accession['subtaxa'];
       }
       else {
@@ -355,7 +355,7 @@
       }
       $results = chado_select_record('organism', ['organism_id'], $match);
       if (count($results) > 1){
-          $this->logMessage('ERROR: The genus, !genus, species, !species, has more than one matched organism in chado.organism.',['!genus' => $genus, '!species' => $one_accession['germplasm_species']], TRIPAL_WARNING);
+          $this->logMessage('ERROR: The genus, !genus, species, !species, infraspecific, !infraspecific, has more than one matched organism in chado.organism.',['!genus' => $genus, '!species' => $one_accession['germplasm_species'], '!infraspecific' => $one_accession['subtaxa']], TRIPAL_WARNING);
           break;
       }
       elseif (count($results) == 1){
@@ -363,7 +363,7 @@
         $organism_id = $results[0]->organism_id;
       }
       else{
-        $this->logMessage('ERROR: The genus, !genus, species, !species, has no matched organism in chado.organism.',['!genus' => $genus, '!species' => $one_accession['germplasm_species']], TRIPAL_WARNING);
+        $this->logMessage('ERROR: The genus, !genus, species, !species, infraspecific, !infraspecific, has no matched organism in chado.organism.',['!genus' => $genus, '!species' => $one_accession['germplasm_species'], '!infraspecific' => $one_accession['subtaxa']], TRIPAL_WARNING);
         break;
       }
 

--- a/includes/TripalImporter/GermplasmAccessionImporter.inc
+++ b/includes/TripalImporter/GermplasmAccessionImporter.inc
@@ -350,6 +350,9 @@
       if ($one_accession['subtaxa']){
         $match['infraspecific_name'] = $one_accession['subtaxa'];
       }
+      else {
+        $match['infraspecific_name'] = NULL;
+      }
       $results = chado_select_record('organism', ['organism_id'], $match);
       if (count($results) > 1){
           $this->logMessage('ERROR: The genus, !genus, species, !species, has more than one matched organism in chado.organism.',['!genus' => $genus, '!species' => $one_accession['germplasm_species']], TRIPAL_WARNING);

--- a/includes/TripalImporter/GermplasmCrossImporter.inc
+++ b/includes/TripalImporter/GermplasmCrossImporter.inc
@@ -74,7 +74,12 @@
     $organisms = array();
     $organisms[''] = '';
     while ($organism = $org_rset->fetchObject()) {
-      $organisms[$organism->organism_id] = "$organism->genus $organism->species ($organism->common_name)";
+      if ($organism->infraspecific_name){
+        $organisms[$organism->organism_id] = "$organism->genus $organism->species $organism->infraspecific_name  ($organism->common_name)";
+      }
+      else{
+        $organisms[$organism->organism_id] = "$organism->genus $organism->species  ($organism->common_name)";
+      }
     }
 
     $form['instructions'] = [


### PR DESCRIPTION
fix the problem of germplasm_accession_loader can not handle infraspecific name properly.

How to test:
(it is recommended to test on development site since infraspecific name is not commenly used and creating an organism with infraspecific name may cause problem for other modules)
1. check your test file, make sure all organism exist in database, specially update you DB with infraspecific name
2. upload your test file
3. check warnings
4. check db if each line (accession) is uploaded to right organism